### PR TITLE
Add more logs on redemption api endpoint

### DIFF
--- a/server/platform/binance/transfer.go
+++ b/server/platform/binance/transfer.go
@@ -68,7 +68,7 @@ func (p *Platform) TransferAssets(addresses []string, assets redemption.Assets) 
 		for _, address := range addresses {
 			addr, err := types.GetFromBech32(address, CurrentNetwork.Bech32Prefixes())
 			if err != nil {
-				logger.Error(err, "AccAddressFromBech32 decode failed", logger.Params{"address": address})
+				logger.Info(err, "AccAddressFromBech32 decode failed", logger.Params{"address": address})
 				continue
 			}
 			transfers = append(transfers, msg.Transfer{

--- a/server/platform/platform.go
+++ b/server/platform/platform.go
@@ -36,7 +36,9 @@ func GetPlatform(coin uint) (redemption.TxApi, error) {
 	}
 	err := p.Init()
 	if err != nil {
-		return nil, errors.E(err, "failed to initialize platform API", errors.Params{"coin": coin})
+		retErr := errors.E(err, "failed to initialize platform API", errors.Params{"coin": coin})
+		logger.Error(retErr)
+		return nil, retErr
 	}
 	return p, nil
 }


### PR DESCRIPTION
Small MR to cleanup and add more logs on redemption endpoint.

Regarding the proposal to send the logs to MongoDB.

- It seems that the logger has integration with Sentry to push the event logs, that could be a good alternative instead of storing directly to DB
[see here](https://github.com/trustwallet/blockatlas/blob/32a3fdaf32a2437c1a902dc25881ebef6f2dc056/pkg/logger/logger.go#L16)

- Another proposal is to save the logs on disk and having a another process to stream the logs files to a log storage (ElasticSearch, MongoDB...) using fluentd for example.
The advantage with this method is that network latency to send the logs out will be decoupled from the application and won't impact the response time.

[Example how to setup logrus for multiple output](https://github.com/sirupsen/logrus/issues/678) 
